### PR TITLE
Working code; siconc 0/100 truncation (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # amipbcs - AMIP dataset prepared for input4MIPs
 
-[![stable version](https://img.shields.io/badge/Current_version-1.1.9-brightgreen.svg)](https://github.com/PCMDI/amipbcs/releases/tag/1.1.9) <!--[![Zenodo DOI](https://zenodo.org/badge/984989836.svg)](https://doi.org/10.5281/zenodo.15446796)-->
+[![stable version](https://img.shields.io/badge/Current_version-1.1.10-brightgreen.svg)](https://github.com/PCMDI/amipbcs/releases/tag/1.1.10) <!--[![Zenodo DOI](https://zenodo.org/badge/984989836.svg)](https://doi.org/10.5281/zenodo.15446796)-->
 
 Code to generate sea surface temperature (SST/tos) and sea ice concentration (siconc) boundary condition data for the AMIP (Atmospheric Model Intercomparison Project) experiment as part of CMIP6, CMIP6Plus and CMIP7 phases and the input4MIPs project.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # amipbcs - AMIP dataset prepared for input4MIPs
 
+[![stable version](https://img.shields.io/badge/Current_version-1.1.9-brightgreen.svg)](https://github.com/PCMDI/amipbcs/releases/tag/1.1.9) <!--[![Zenodo DOI](https://zenodo.org/badge/984989836.svg)](https://doi.org/10.5281/zenodo.15446796)-->
+
 Code to generate sea surface temperature (SST/tos) and sea ice concentration (siconc) boundary condition data for the AMIP (Atmospheric Model Intercomparison Project) experiment as part of CMIP6, CMIP6Plus and CMIP7 phases and the input4MIPs project.
 
 The latest generated data can be obtained from the [ESGF2-US data portal](https://esgf-node.ornl.gov/search?project=input4MIPs&activeFacets={%22mip_era%22:%22CMIP7%22})

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The latest generated data can be obtained from the [ESGF2-US data portal](https:
 The code depends upon the following packages:
 - [**xCDAT 0.9.1+**](https://github.com/xCDAT/xcdat) (Available through [conda-forge](https://anaconda.org/conda-forge/xcdat/files))
 - [**CMOR 3.11.0+**](https://github.com/PCMDI/cmor) (Available through [conda-forge](https://anaconda.org/conda-forge/cmor/files))
-- [**gfortran 14.2.0+**](https://gcc.gnu.org/wiki/GFortran) (Available through [conda-forge](https://anaconda.org/conda-forge/gfortran/files))
+- [**gfortran 15.1.0+**](https://gcc.gnu.org/wiki/GFortran) (Available through [conda-forge](https://anaconda.org/conda-forge/gfortran/files))
 - [**Python 3.11.13**](https://www.python.org/) (Available through [conda-forge](https://anaconda.org/conda-forge/python/files); Not latest due to unsolved Meson dependency with Python 3.12+, see [mesonbuild/meson/issues#14830](https://github.com/mesonbuild/meson/issues/14830))
 
 These packages and libraries are available for linux-64, osx-64 and osx-arm64 (x86_64) architectures

--- a/pcmdiAmipBcs/pcmdiAmipBcsFx.py
+++ b/pcmdiAmipBcs/pcmdiAmipBcsFx.py
@@ -24,6 +24,7 @@ PJD 25 Jul 2025 - Started remapping cdms2 to xcdat
 PJD 25 Jul 2025 - Completed remapping cdms2 -> xcdat/xarray
 PJD 29 Jul 2025 - Reformatted getNumDays prints
 PJD 29 Jul 2025 - Cleaned up createMonthlyMidpoints; debugs rewritten to xcdat
+PJD  4 Aug 2025 - Update to createMonthlyMidpoints to use passed units
 
 @author: pochedls and durack1
 """
@@ -255,6 +256,7 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
     PJD  2 Dec 2021 - Updated addClimo call with t/vmax and vmin args
     PJD 25 Jul 2025 - Remapped cdms2 calls to xcdat
     PJD 29 Jul 2025 - Further cleanups, syntactic
+    PJD  4 Aug 2025 - updated to remove tosi.units reference, passed arg
 
     """
     # regrid data if needed
@@ -268,7 +270,6 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
     time = tosi.cf["time"]
     lat = tosi.cf["latitude"]
     lon = tosi.cf["longitude"]
-    units = tosi.units
 
     # deal with optional arguments
     if "mask" in kargs:

--- a/pcmdiAmipBcs/pcmdiAmipBcsFx.py
+++ b/pcmdiAmipBcs/pcmdiAmipBcsFx.py
@@ -28,7 +28,7 @@ PJD 29 Jul 2025 - Reformatted getNumDays prints
 """
 
 # %% imports
-import pcmdiAmipBcs  # pcmdiAmipBcs.cpython-39-x86_64-linux-gnu - see files in __pycache__ subdir
+import pcmdiAmipBcs  # pcmdiAmipBcs.cpython-39-x86_64-linux-gnu/pcmdiAmipBcs.cpython-311-darwin.so - see files in __pycache__ subdir
 import numpy as np
 
 # Control debug output format
@@ -54,7 +54,14 @@ def getNumDays(time):
         y = time.dt.year[i].data
         m = time.dt.month[i].data
         fdays = monthrange(y, m)[1]
-        print("getNumDays: y", y, "m", m, "fdays", fdays)
+        print(
+            "getNumDays: y",
+            "{:04d}".format(y),
+            "m",
+            "{:02d}".format(m),
+            "fdays",
+            "{:02d}".format(fdays),
+        )
         ndays[i] = fdays
     return ndays
 
@@ -411,15 +418,45 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
 
                 # Debug for example issues
                 # if alat == -77.5 and alon == 182.5:
-                # # call solver
-                #     (ss, icnt, niter, notconverg, jj, resid, residmax, jumps)\
-                #     = pcmdiAmipBcs.solvmid(alon, alat, conv, dt, tmin, tmax, bbmin,
-                #                         maxiter, aa, cc, obsmean, jcnt)
+                #     # call solver
+                #     (ss, icnt, niter, notconverg, jj, resid, residmax, jumps) = (
+                #         pcmdiAmipBcs.solvmid(
+                #             alon,
+                #             alat,
+                #             conv,
+                #             dt,
+                #             vmin,
+                #             vmax,
+                #             bbmin,
+                #             maxiter,
+                #             aa,
+                #             cc,
+                #             obsmean,
+                #             jcnt,
+                #         )
+                #     )
+                #     print("alat == -77.5 and alon == 182.5")
+                #     pdb.set_trace()
                 # elif alat == -76.5 and alon == 186.5:
-                # # call solver
-                #     (ss, icnt, niter, notconverg, jj, resid, residmax, jumps)\
-                #     = pcmdiAmipBcs.solvmid(alon, alat, conv, dt, tmin, tmax, bbmin,
-                #                         maxiter, aa, cc, obsmean, jcnt)
+                #     # call solver
+                #     (ss, icnt, niter, notconverg, jj, resid, residmax, jumps) = (
+                #         pcmdiAmipBcs.solvmid(
+                #             alon,
+                #             alat,
+                #             conv,
+                #             dt,
+                #             vmin,
+                #             vmax,
+                #             bbmin,
+                #             maxiter,
+                #             aa,
+                #             cc,
+                #             obsmean,
+                #             jcnt,
+                #         )
+                #     )
+                #     print("alat == -76.5 and alon == 186.5")
+                #     pdb.set_trace()
                 # else:
                 #     continue
 
@@ -450,19 +487,19 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
                 # Debug solver output
                 # inds = np.where(np.isnan(ss))[0]
                 # if len(inds) > 0:
-                #    plt.plot(ss[inds[0] - 12 : inds[0] + 12]-10, label="output-10")
-                #    plt.plot(obsmean[inds[0] - 12 : inds[0] + 12], label="input")
-                #    print(' '.join(["lat:", str(alat), "lon:", str(alon)]))
-                #    print('input:')
-                #    print(obsmean[inds[0] - 12 : inds[0] + 12])
-                #    print('output:')
-                #    print(ss[inds[0] - 12 : inds[0] + 12])
-                #    plt.title(' '.join(["lat:", str(alat), "lon:", str(alon)]))
-                #    plt.legend()
-                #    plt.show()
-                #    print("stepping..")
+                #     plt.plot(ss[inds[0] - 12 : inds[0] + 12] - 10, label="output-10")
+                #     plt.plot(obsmean[inds[0] - 12 : inds[0] + 12], label="input")
+                #     print(" ".join(["lat:", str(alat), "lon:", str(alon)]))
+                #     print("input:")
+                #     print(obsmean[inds[0] - 12 : inds[0] + 12])
+                #     print("output:")
+                #     print(ss[inds[0] - 12 : inds[0] + 12])
+                #     plt.title(" ".join(["lat:", str(alat), "lon:", str(alon)]))
+                #     plt.legend()
+                #     plt.show()
+                #     print("stepping..")
 
-            # subset time series (remove padded months) and add to array
+            # subset time series (remove padded months) and add to output array
             # assumes start is padded with 24 months, end padded by edaysl = len(edays)
             tosimp[:, i, j] = ss[24:-edaysl]
 

--- a/pcmdiAmipBcs/pcmdiAmipBcsFx.py
+++ b/pcmdiAmipBcs/pcmdiAmipBcsFx.py
@@ -22,6 +22,7 @@ PJD  2 Dec 2021 - Code and print diagnostic cleanup
 PJD  2 Dec 2021 - Renamed hurrellfx.py -> pcmdiAmipBcsFx.py
 PJD 25 Jul 2025 - Started remapping cdms2 to xcdat
 PJD 25 Jul 2025 - Completed remapping cdms2 -> xcdat/xarray
+PJD 29 Jul 2025 - Reformatted getNumDays prints
 
 @author: pochedls and durack1
 """
@@ -51,10 +52,9 @@ def getNumDays(time):
     ndays = np.zeros(len(time), dtype=int)
     for i in range(len(time)):
         y = time.dt.year[i].data
-        print("getNumDays: y", y)
         m = time.dt.month[i].data
-        print("getNumDays: m", m)
         fdays = monthrange(y, m)[1]
+        print("getNumDays: y", y, "m", m, "fdays", fdays)
         ndays[i] = fdays
     return ndays
 
@@ -246,6 +246,7 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
     PJD 22 Nov 2021 - Updated jcnt np.array -> int type and back -> np.array
     PJD  2 Dec 2021 - Updated addClimo call with t/vmax and vmin args
     PJD 25 Jul 2025 - Remapped cdms2 calls to xcdat
+    PJD 29 Jul 2025 - Further cleanups, syntactic
 
     """
     # regrid data if needed
@@ -313,10 +314,10 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
 
     # evaluate padding - check Jan 1870-2, Dec timeEnd+2 for discontinuity
     aCount = 0
-    padPlot = 0
+    padPlot = 0  # turn off = 0
     print("Check padded timeseries for start/end >96% discontinuities")
-    for i in range(len(lat)):
-        for j in range(len(lon)):
+    for i, _ in enumerate(lat):
+        for j, _ in enumerate(lon):
             if lat[i] > -91:  # 80
                 # Calculate discontinuities >96%
                 tosipDiff = tosip[0, i, j] - tosip[-1, i, j]
@@ -338,7 +339,7 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
                     )
                     plt.plot(
                         np.arange(0, 60),
-                        tosip[0:60, i, j].data + 5,
+                        tosip[0:60, i, j] + 5,
                         label="start tosip+5",
                     )
                     ax1.legend()
@@ -352,7 +353,7 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
                     )
                     plt.plot(
                         np.arange(0, 60),
-                        tosip[-60:, i, j].data + 5,
+                        tosip[-60:, i, j] + 5,
                         label="end tosip+5",
                     )
                     ax2.legend()
@@ -398,8 +399,8 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
     # loop over each grid cell and create midpoint values
     sumnotconverg, allresidmax = [0.0 for _ in range(2)]
     icnttot, nitertot, minall, maxall, jjall = [0 for _ in range(5)]
-    for i in range(len(lat)):
-        for j in range(len(lon)):
+    for i, _ in enumerate(lat):
+        for j, _ in enumerate(lon):
             obsmean = np.array(tosip[:, i, j])  # extract gridpoint time series
             # lat / lon for diagnostics - not needed?
             alat = lat[i]
@@ -469,27 +470,27 @@ def createMonthlyMidpoints(tosi, ftype, units, nyears, varOut, **kargs):
             if notconverg > 0:
                 print(
                     "Not converged - ",
-                    "j:",
+                    "j:      ",
                     j,
-                    "alon:",
+                    "alon:   ",
                     alon,
-                    "i:",
+                    "i:      ",
                     i,
-                    "alat:",
+                    "alat:   ",
                     alat,
-                    "conv:",
+                    "conv:   ",
                     conv,
-                    "dt:",
+                    "dt:     ",
                     dt,
-                    "vmin:",
+                    "vmin:   ",
                     vmin,
-                    "vmax:",
+                    "vmax:   ",
                     vmax,
-                    "bbmin:",
+                    "bbmin:  ",
                     bbmin,
                     "maxiter:",
                     maxiter,
-                    "jcnt:",
+                    "jcnt:   ",
                     jcnt,
                 )
                 print(
@@ -599,7 +600,6 @@ def fillVoid(data):
     for i in range(len(time)):
         flag = flagAll[i, :, :]
         dataSlice = data[i, :, :]
-        # iterCount = 0
         nlflags = 0
         iterCount = 0
         while np.any(~flag):  # as long as there are any False's in flag

--- a/pcmdiAmipBcs/pcmdiAmipBcsFx.py
+++ b/pcmdiAmipBcs/pcmdiAmipBcsFx.py
@@ -23,6 +23,7 @@ PJD  2 Dec 2021 - Renamed hurrellfx.py -> pcmdiAmipBcsFx.py
 PJD 25 Jul 2025 - Started remapping cdms2 to xcdat
 PJD 25 Jul 2025 - Completed remapping cdms2 -> xcdat/xarray
 PJD 29 Jul 2025 - Reformatted getNumDays prints
+PJD 29 Jul 2025 - Cleaned up createMonthlyMidpoints; debugs rewritten to xcdat
 
 @author: pochedls and durack1
 """

--- a/src/cmorize.py
+++ b/src/cmorize.py
@@ -20,6 +20,7 @@ PJD 29 Jul 25 - updated to replace time_bnds with generated calendar
                 xarray.date_range
 PJD  4 Aug 25 - updated for perlmutter and paths
 PJD  5 Aug 25 - added data_update_notes and doi global_atts
+PJD  6 Aug 25 - added dataRepo, dataUpdateNotes and doi across files
 """
 
 # %% imports
@@ -40,17 +41,50 @@ import pcmdiAmipBcsFx
 # %% set data version info
 activity_id = "input4MIPs"
 contact = "pcmdi-cmip@llnl.gov"
-dataVerNum = "1.1.10"  # WILL REQUIRE UPDATING
+dataUpdateNotes = (
+    "".join(
+        [
+            "v1.1.9 and v1.1.10 differences: this ",
+            "update changes a single month (Dec-22) ",
+            "erroneous sea ice concentration ",
+            "(siconc). Due to the tapering affect ",
+            "of the 'diddling' method, some very ",
+            "small changes (<1 percent) can be seen ",
+            "starting in August 2022 in diddled ",
+            "fields (siconcbcs). For v1.1.10 a ",
+            "climatology-anomaly infill was ",
+            "undertaken, replacing the Dec-22 ",
+            "problem values. For more details, see ",
+            "https://nbviewer.org/github/durack1/",
+            "notebooks/blob/main/jlnbs/PCMDI-AMIP-",
+            "queryOISST2-0Data.ipynb; There are no ",
+            "changes to either the SST (tos) or ",
+            "diddled SST (tosbcs) fields; NOAA OISST ",
+            "v2.0 data was deprecated in February ",
+            "2023, and no further PCMDI-AMIP-1-x-y ",
+            "updates will be produced. Ongoing ",
+            "discussions focused on a v2.0 product ",
+            "continue see https://github.com/PCMDI/",
+            "amipbcs/issues/6.",
+        ]
+    ),
+)
+dataRepo = "https://github.com/PCMDI/amipbcs"
+# WILL REQUIRE UPDATING
+dataVerNum = "1.1.10"
 dataVer = "PCMDI-AMIP-XX".replace("XX", dataVerNum.replace(".", "-"))
 dataVerSht = "".join(["v", dataVerNum])
 data_structure = "grid"
+doi = "https://doi.org/10.25981/ESGF.input4MIPs.CMIP7/2575015"
 frequency = "mon"
-further_info_url = "https://pcmdi.llnl.gov/mips/amip/"  # WILL REQUIRE UPDATING - point to GMD paper when available
+# WILL REQUIRE UPDATING - point to GMD paper when available
+further_info_url = "https://pcmdi.llnl.gov/mips/amip/"
 institution_id = "PCMDI"
 institution = " ".join(
     [
         "Program for Climate Model Diagnosis and Intercomparison,",
-        "Lawrence Livermore National Laboratory, Livermore, CA 94550, USA",
+        "Lawrence Livermore National Laboratory, Livermore, CA",
+        "94550, USA (ROR: https://ror.org/02k3nmd98)",
     ]
 )
 last_year = "2022"  # WILL REQUIRE UPDATING
@@ -58,7 +92,8 @@ last_month = 12  # WILL REQUIRE UPDATING
 comment = "".join(
     [
         "Based on Hurrell SST/sea ice consistency criteria applied to ",
-        "merged HadISST (1870-01 to 1981-10) & NCEP-0I2 (1981-11 to ",
+        "merged HadISST v1.0 (1870-01 to 1981-10) & NCEP-0ISST v2.0 ",
+        "(1981-11 to ",
         last_year,
         "-",
         "{:0>2}".format(last_month),
@@ -95,12 +130,17 @@ ref_bcs = " ".join(
         "temperature and sea ice concentration boundary conditions for",
         "AMIP II simulations. PCMDI Report 60, Program for Climate Model",
         "Diagnosis and Intercomparison, Lawrence Livermore National",
-        "Laboratory, 25 pp. Available online: https://pcmdi.llnl.gov/report/pdf/60.pdf",
+        "Laboratory, 25 pp. Available online:",
+        "https://pcmdi.llnl.gov/report/pdf/60.pdf",
     ]
 )
-source = "PCMDI-AMIP XX: Merged SST based on UK MetOffice HadISST and NCEP OI2".replace(
-    "XX", dataVerNum
+source = " ".join(
+    [
+        "PCMDI-AMIP XX: Merged SST based on UK MetOffice HadISST v1.0",
+        "and NCEP OISST v2.0",
+    ]
 )
+source.replace("XX", dataVerNum)
 target_mip = "CMIP"
 time_period = "".join(["187001-", last_year, "{:0>2}".format(last_month)])
 
@@ -224,38 +264,9 @@ for varId in ["siconc", "tos"]:
 
         # Force local file attribute as history
         cmor.set_cur_dataset_attribute("history", history)
-        cmor.set_cur_dataset_attribute(
-            "data_update_notes",
-            "".join(
-                [
-                    "v1.1.9 and v1.1.10 differences: this ",
-                    "update changes a single month (Dec-22) ",
-                    "erroneous sea ice concentration ",
-                    "(siconc). Due to the tapering affect ",
-                    'of the "diddling" method, some very ',
-                    "small changes (<1 percent) can be seen ",
-                    "starting in August 2022 in diddled ",
-                    "fields (siconcbcs). For v1.1.10 a ",
-                    "climatology-anomaly infill was ",
-                    "undertaken, replacing the problem ",
-                    "Dec-22 values. For more details, see ",
-                    "https://nbviewer.org/github/durack1/",
-                    "notebooks/blob/main/jlnbs/PCMDI-AMIP-",
-                    "queryOISST2-0Data.ipynb; There are no ",
-                    "changes to either the SST (tos) or ",
-                    "diddled SST (tosbcs) fields; NOAA OISST ",
-                    "v2.0 data was deprecated in February ",
-                    "2023, and no further updates will ",
-                    "be produced. Ongoing discussions ",
-                    "focused on a v2.0 product continue ",
-                    "see https://github.com/PCMDI/amipbcs/",
-                    "issues/6.",
-                ]
-            ),
-        )
-        cmor.set_cur_dataset_attribute(
-            "doi", "https://doi.org/10.25981/ESGF.input4MIPs.CMIP7/xxx"
-        )
+        cmor.set_cur_dataset_attribute("data_repo", dataRepo)
+        cmor.set_cur_dataset_attribute("data_update_notes", dataUpdateNotes)
+        cmor.set_cur_dataset_attribute("doi", doi)
 
         # Toggle data and appropriate table
         if "sic" in varId:
@@ -370,6 +381,9 @@ for fxVar in fxFiles:
 
     # Force local file attribute as history
     cmor.set_cur_dataset_attribute("history", history)
+    cmor.set_cur_dataset_attribute("data_repo", dataRepo)
+    cmor.set_cur_dataset_attribute("data_update_notes", dataUpdateNotes)
+    cmor.set_cur_dataset_attribute("doi", doi)
 
     # Load relevant table file
     tablePath = "Tables"

--- a/src/cmorize.py
+++ b/src/cmorize.py
@@ -21,6 +21,7 @@ PJD 29 Jul 25 - updated to replace time_bnds with generated calendar
 PJD  4 Aug 25 - updated for perlmutter and paths
 PJD  5 Aug 25 - added data_update_notes and doi global_atts
 PJD  6 Aug 25 - added dataRepo, dataUpdateNotes and doi across files
+PJD  7 Aug 25 - dataUpdateNotes formatting tweak
 """
 
 # %% imports
@@ -41,33 +42,31 @@ import pcmdiAmipBcsFx
 # %% set data version info
 activity_id = "input4MIPs"
 contact = "pcmdi-cmip@llnl.gov"
-dataUpdateNotes = (
-    "".join(
-        [
-            "v1.1.9 and v1.1.10 differences: this ",
-            "update changes a single month (Dec-22) ",
-            "erroneous sea ice concentration ",
-            "(siconc). Due to the tapering affect ",
-            "of the 'diddling' method, some very ",
-            "small changes (<1 percent) can be seen ",
-            "starting in August 2022 in diddled ",
-            "fields (siconcbcs). For v1.1.10 a ",
-            "climatology-anomaly infill was ",
-            "undertaken, replacing the Dec-22 ",
-            "problem values. For more details, see ",
-            "https://nbviewer.org/github/durack1/",
-            "notebooks/blob/main/jlnbs/PCMDI-AMIP-",
-            "queryOISST2-0Data.ipynb; There are no ",
-            "changes to either the SST (tos) or ",
-            "diddled SST (tosbcs) fields; NOAA OISST ",
-            "v2.0 data was deprecated in February ",
-            "2023, and no further PCMDI-AMIP-1-x-y ",
-            "updates will be produced. Ongoing ",
-            "discussions focused on a v2.0 product ",
-            "continue see https://github.com/PCMDI/",
-            "amipbcs/issues/6.",
-        ]
-    ),
+dataUpdateNotes = "".join(
+    [
+        "v1.1.9 and v1.1.10 differences: this ",
+        "update changes a single month (Dec-22) ",
+        "erroneous sea ice concentration ",
+        "(siconc). Due to the tapering affect ",
+        "of the 'diddling' method, some very ",
+        "small changes (<1 percent) can be seen ",
+        "starting in August 2022 in diddled ",
+        "fields (siconcbcs). For v1.1.10 a ",
+        "climatology-anomaly infill was ",
+        "undertaken, replacing the Dec-22 ",
+        "problem values. For more details, see ",
+        "https://nbviewer.org/github/durack1/",
+        "notebooks/blob/main/jlnbs/PCMDI-AMIP-",
+        "queryOISST2-0Data.ipynb; There are no ",
+        "changes to either the SST (tos) or ",
+        "diddled SST (tosbcs) fields; NOAA OISST ",
+        "v2.0 data was deprecated in February ",
+        "2023, and no further PCMDI-AMIP-1-x-y ",
+        "updates will be produced. Ongoing ",
+        "discussions focused on a v2.0 product ",
+        "continue, see https://github.com/PCMDI/",
+        "amipbcs/issues/6.",
+    ]
 )
 dataRepo = "https://github.com/PCMDI/amipbcs"
 # WILL REQUIRE UPDATING

--- a/src/cmorize.py
+++ b/src/cmorize.py
@@ -19,6 +19,7 @@ PJD 29 Jul 25 - further updates further cleaning up redundant code
 PJD 29 Jul 25 - updated to replace time_bnds with generated calendar
                 xarray.date_range
 PJD  4 Aug 25 - updated for perlmutter and paths
+PJD  5 Aug 25 - added data_update_notes and doi global_atts
 """
 
 # %% imports
@@ -27,7 +28,7 @@ import cmor
 import datetime
 import numpy as np
 import os
-import socket
+import subprocess
 import sys
 import xcdat as xc
 import xarray as xr
@@ -111,7 +112,7 @@ history = " ".join(["File processed:", timeFormat, "UTC; San Francisco, CA, USA"
 host = "".join(
     [
         "Host: ",
-        socket.gethostname(),
+        subprocess.check_output(["hostname", "-f"], text=True).strip(),
         "; xCDAT version: ",
         xcVersion,
         "; Python version: ",
@@ -223,6 +224,40 @@ for varId in ["siconc", "tos"]:
 
         # Force local file attribute as history
         cmor.set_cur_dataset_attribute("history", history)
+        cmor.set_cur_dataset_attribute(
+            "data_update_notes",
+            "".join(
+                [
+                    "v1.1.9 and v1.1.10 differences: this ",
+                    "update changes a single month (Dec-22) ",
+                    "erroneous sea ice concentration ",
+                    "(siconc). Due to the tapering affect ",
+                    'of the "diddling" method, some very ',
+                    "small changes (<1 percent) can be seen ",
+                    "starting in August 2022 in diddled ",
+                    "fields (siconcbcs). For v1.1.10 a ",
+                    "climatology-anomaly infill was ",
+                    "undertaken, replacing the problem ",
+                    "Dec-22 values. For more details, see ",
+                    "https://nbviewer.org/github/durack1/",
+                    "notebooks/blob/main/jlnbs/PCMDI-AMIP-",
+                    "queryOISST2-0Data.ipynb; There are no ",
+                    "changes to either the SST (tos) or ",
+                    "diddled SST (tosbcs) fields; NOAA OISST ",
+                    "v2.0 data was deprecated in February ",
+                    "2023, and no further updates will ",
+                    "be produced. Ongoing discussions ",
+                    "focused on a v2.0 product continue ",
+                    "see https://github.com/PCMDI/amipbcs/",
+                    "issues/6.",
+                ]
+            ),
+        )
+        cmor.set_cur_dataset_attribute(
+            "doi", "https://doi.org/10.25981/ESGF.input4MIPs.CMIP7/xxx"
+        )
+
+        # Toggle data and appropriate table
         if "sic" in varId:
             table = "input4MIPs_SImon.json"
         else:

--- a/src/cmorize.py
+++ b/src/cmorize.py
@@ -277,6 +277,8 @@ for varId in ["siconc", "tos"]:
 # areacello
 areacello = fH.spatial.get_weights(axis="Y")
 areacello, _ = xr.broadcast(areacello, var[0])
+areacello = areacello / 720.0  #
+pdb.set_trace()
 # areacello.sum() = 1.0
 earthSurfaceArea = 510.1
 # million km2

--- a/src/createCVs.ipynb
+++ b/src/createCVs.ipynb
@@ -491,7 +491,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cmor3110xcd090",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -505,7 +505,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/src/matPlot.py
+++ b/src/matPlot.py
@@ -23,6 +23,7 @@ PJD 29 Jul 2025 - Updating for mac-local v1.1.10 v20250724 -> 20250729
 PJD  4 Aug 2025 - Updating for perlmutter v1.1.10
 PJD  4 Aug 2025 - Updated output *mp4 to take verId as filename arg
 PJD  6 Aug 2025 - Updated for latest/final 250806 data
+PJD  7 Aug 2025 - Updated for final 250807 data
 
 @author: durack1
 """
@@ -295,7 +296,7 @@ outPath = "/global/homes/d/durack1/git/amipbcs"
 verId = "v1.1.10"
 # verPath = "/p/user_pub/climate_work/durack1/"  # LLNL/detect
 verPath = "/global/homes/d/durack1/git/amipbcs"
-ver = "v20250806"  # Update for each run
+ver = "v20250807"  # Update for each run
 verPath = os.path.join(verPath, "input4MIPs/CMIP7/CMIP/PCMDI/PCMDI-AMIP-1-1-10/")
 print("verPath:", verPath)
 # tos_input4MIPs_SSTsAndSeaIce_CMIP_PCMDI-AMIP-1-2-0_gn_187001-202108.nc

--- a/src/matPlot.py
+++ b/src/matPlot.py
@@ -20,6 +20,8 @@ PJD 12 May 2023 - Updated for latest v1.1.9 data run
 PJD 18 May 2023 - Compare v1.1.9 versions (released 20230512, and new mamba env 20230518)
 PJD 24 Jul 2025 - Updating for mac-local v1.1.10 vs v1.1.9
 PJD 29 Jul 2025 - Updating for mac-local v1.1.10 v20250724 -> 20250729
+PJD  4 Aug 2025 - Updating for perlmutter v1.1.10
+PJD  4 Aug 2025 - Updated output *mp4 to take verId as filename arg
 
 @author: durack1
 """
@@ -34,8 +36,6 @@ import numpy as np
 import os
 import shutil
 from xcdat import open_dataset
-
-# import pdb
 
 # %% function defs
 
@@ -303,7 +303,6 @@ print("verPath:", verPath)
 verOldId = "v1.1.9"
 verOld = "v20230512"  # Update for each run
 # verOldPath = "/p/user_pub/work/input4MIPs/CMIP6Plus/CMIP/PCMDI/PCMDI-AMIP-1-1-9/"  # LLNL/detect
-# verOldPath = "../"
 verOldPath = "/global/cfs/projectdirs/m4931/gsharing/user_pub_work"
 verOldPath = os.path.join(
     verOldPath, "input4MIPs/CMIP6Plus/CMIP/PCMDI/PCMDI-AMIP-1-1-9/"
@@ -421,7 +420,7 @@ for var in ["siconc", "siconcbcs", "tos", "tosbcs"]:
             os.path.join(
                 outPath,
                 "pngs",
-                "_".join(["AMIPBCS_newVsOld", var, "v1-1-9", "".join([ver, ".mp4"])]),
+                "_".join(["AMIPBCS_newVsOld", var, verId, "".join([ver, ".mp4"])]),
             ),
             crf=20,
             preset="slower",
@@ -434,229 +433,3 @@ for var in ["siconc", "siconcbcs", "tos", "tosbcs"]:
     # .filter('deflicker', mode='pm', size=10)
     # .filter('scale', size='hd1080', force_original_aspect_ratio='increase')
     # ffmpeg -framerate 48 -i %04d_ESGF-PubStatsPB-MSSans.png 230117_output_48.mp4
-
-"""
-        # Open canvas
-        fig = plt.figure(figsize=(10, 15))
-        plt.axis("off")
-        plt.ioff()  # turn off interactive plots - background mode
-        plt.title(timeString)
-        # Start subplots
-        ax1 = fig.add_subplot(
-            3,
-            1,
-            1,
-            projection=ccrs.Robinson(
-                central_longitude=centralLon,
-                globe=None,
-                false_easting=None,
-                false_northing=None,
-            ),
-        )
-        cs1 = ax1.contourf(
-            x,
-            y,
-            s1[
-                0,
-            ],
-            levs1,
-            transform=ccrs.PlateCarree(),
-            cmap=cmap,
-        )
-        tx1 = plt.text(
-            labX,
-            labY,
-            "v1.1.8",
-            fontsize=fntsz,
-            horizontalalignment="center",
-            transform=ccrs.Geodetic(),
-        )
-        ax2 = fig.add_subplot(
-            3,
-            1,
-            2,
-            projection=ccrs.Robinson(
-                central_longitude=centralLon,
-                globe=None,
-                false_easting=None,
-                false_northing=None,
-            ),
-        )
-        cs2 = ax2.contourf(
-            x,
-            y,
-            s2[
-                0,
-            ],
-            levs1,
-            transform=ccrs.PlateCarree(),
-            cmap=cmap,
-        )
-        tx2 = plt.text(
-            labX,
-            labY,
-            "v1.1.9",
-            fontsize=fntsz,
-            horizontalalignment="center",
-            transform=ccrs.Geodetic(),
-        )
-        ax3 = fig.add_subplot(
-            3,
-            1,
-            3,
-            projection=ccrs.Robinson(
-                central_longitude=centralLon,
-                globe=None,
-                false_easting=None,
-                false_northing=None,
-            ),
-        )
-        # Generate % change
-        diff = (
-            s1[0,]
-            - s2[0,]
-        )
-        inds = np.nonzero(diff.data)
-        diffnew = np.ma.zeros(diff.shape)
-        denom = (np.abs(s1[0,]) + np.abs(s2[0,])) / 2
-        np.squeeze(denom).shape
-        diffnew[inds] = diff.data[inds] / denom.data[inds]
-        cs3 = ax3.contourf(
-            x,
-            y,
-            diffnew,
-            levs3,
-            transform=ccrs.PlateCarree(),
-            cmap=cmap,
-        )
-        tx3 = plt.text(
-            labX,
-            labY,
-            "v1.1.8 - v1.1.9",
-            fontsize=fntsz,
-            horizontalalignment="center",
-            transform=ccrs.Geodetic(),
-        )
-        # make the map global rather than have it zoom in to the extents of
-        # any plotted data ax.set_global()
-        # ax1.stock_img()
-        ax1.coastlines()
-        ax2.coastlines()
-        ax3.coastlines()
-        # ax.plot(-0.08, 51.53, 'o', transform=ccrs.PlateCarree())
-        # ax.plot([-0.08, 132], [51.53, 43.17], transform=ccrs.PlateCarree())
-        # ax.plot([-0.08, 132], [51.53, 43.17], transform=ccrs.Geodetic())
-        # https://matplotlib.org/stable/gallery/axes_grid1/demo_colorbar_with_inset_locator.html
-        axin1 = inset_axes(
-            ax1,
-            width="5%",  # width = 5% of parent_bbox width
-            height="50%",  # height : 50%
-            loc="lower left",
-            bbox_to_anchor=(1.05, -1.17, 1, 4.3),
-            bbox_transform=ax1.transAxes,
-            borderpad=0,
-        )
-        axin3 = inset_axes(
-            ax3,
-            width="5%",  # width = 5% of parent_bbox width
-            height="50%",  # height : 50%
-            loc="lower left",
-            bbox_to_anchor=(1.05, 0.0, 1, 2),
-            bbox_transform=ax3.transAxes,
-            borderpad=0,
-        )
-        # cax1 = plt.axes([0.1, 0.63, 0.75, 0.02])
-        # fig.colorbar(ax1, cax=cax2, orientation='horizontal', cmap='RdBu')
-        cax1 = fig.colorbar(cs1, cax=axin1)
-        cax1.ax.set_ylabel("% coverage", rotation=270)
-        cax2 = fig.colorbar(cs3, cax=axin3)
-        cax2.ax.set_ylabel("% difference", rotation=270)
-        # Resize plots
-        plt.subplots_adjust(
-            bottom=0.005, left=0.01, right=0.84, top=0.985, hspace=0.01, wspace=0.01
-        )
-        # plt.show()
-        fig.savefig(
-            "".join(["/home/durack1/git/amipbcs/", timeString, ".png"]), dpi=100)
-"""
-
-"""
-# %% Tweaked plot - % errors
-
-# First ascertain differences as a %
-oldMinusNew = s1 - s2
-# Mask all exact matches = 0.0 and 100.
-oldMinusNew = np.where(oldMinusNew == 0.0, 1e20, oldMinusNew)
-oldMinusNew = np.where(oldMinusNew == 100.0, 1e20, oldMinusNew)
-# Now convert missing values to mask
-oldMinusNew = np.ma.masked_where(oldMinusNew == 1e20, oldMinusNew, copy=False)
-# Generate absolute difference as %
-diffPercent = np.ma.abs(oldMinusNew) / np.ma.abs(s2)
-# Now mask regions where x < 0.2%, .2/100 or 0.002
-diffPercentMasked = np.ma.where(diffPercent < 0.002, 1e20, diffPercent)
-# Now convert missing values to mask
-diffPercentMasked = np.ma.masked_where(
-    diffPercentMasked == 1e20, diffPercentMasked, copy=False
-)
-# Generate index of nonzeros
-ind = diffPercentMasked.nonzero()
-# Contour levels
-levs4 = list(np.arange(-1, 1.0000001, 0.1) * 0.1)
-# Lab x, y
-labX = -140.0
-centralLon = 202
-labY = 0.0
-fntsz = "large"
-cmap = "cool"  # 'RdBu'
-# https://matplotlib.org/stable/tutorials/colors/colormaps.html
-fig2 = plt.figure(figsize=(10, 10))
-plt.axis("off")
-plt.title("1871-1-1")
-# Start subplots
-ax21 = fig2.add_subplot(
-    1,
-    1,
-    1,
-    projection=ccrs.Robinson(
-        central_longitude=centralLon,
-        globe=None,
-        false_easting=None,
-        false_northing=None,
-    ),
-)
-cs1 = ax21.contourf(
-    x,
-    y,
-    diffPercentMasked[
-        0,
-    ],
-    levs4,
-    transform=ccrs.PlateCarree(),
-    cmap=cmap,
-)
-tx1 = plt.text(
-    labX,
-    labY,
-    "v1.1.6 - v1.2.0 %",
-    fontsize=fntsz,
-    horizontalalignment="right",
-    transform=ccrs.Geodetic(),
-)
-axin4 = inset_axes(
-    ax21,
-    width="5%",  # width = 5% of parent_bbox width
-    height="50%",  # height : 50%
-    loc="lower left",
-    borderpad=0,
-    bbox_transform=ax21.transAxes,
-    bbox_to_anchor=(0, -0.2, 20, 0.2),
-)
-fig2.colorbar(cs1, cax=axin4, orientation="horizontal")
-plt.show()
-fig2.savefig("/home/durack1/git/amipbcs/matPlotTmpDiff.png", dpi=300)
-# %% Generate stat differences
-# In [93]: s1.data[ind]  # absolute original number
-# In [94]: s2.data[ind]  # absolute new numbers
-# In [95]: s1.data[ind]-s2.data[ind]  # absolute differences
-# In [98]: ((s1.data[ind]-s2.data[ind])/s2.data[ind])*100.  # % differences
-"""

--- a/src/matPlot.py
+++ b/src/matPlot.py
@@ -22,6 +22,7 @@ PJD 24 Jul 2025 - Updating for mac-local v1.1.10 vs v1.1.9
 PJD 29 Jul 2025 - Updating for mac-local v1.1.10 v20250724 -> 20250729
 PJD  4 Aug 2025 - Updating for perlmutter v1.1.10
 PJD  4 Aug 2025 - Updated output *mp4 to take verId as filename arg
+PJD  6 Aug 2025 - Updated for latest/final 250806 data
 
 @author: durack1
 """
@@ -293,9 +294,8 @@ outPath = "/global/homes/d/durack1/git/amipbcs"
 # New data
 verId = "v1.1.10"
 # verPath = "/p/user_pub/climate_work/durack1/"  # LLNL/detect
-# verPath = "../"
 verPath = "/global/homes/d/durack1/git/amipbcs"
-ver = "v20250804"  # Update for each run
+ver = "v20250806"  # Update for each run
 verPath = os.path.join(verPath, "input4MIPs/CMIP7/CMIP/PCMDI/PCMDI-AMIP-1-1-10/")
 print("verPath:", verPath)
 # tos_input4MIPs_SSTsAndSeaIce_CMIP_PCMDI-AMIP-1-2-0_gn_187001-202108.nc

--- a/src/matPlot.py
+++ b/src/matPlot.py
@@ -287,22 +287,24 @@ def plotter(
 
 # %% Variables
 
-outPathVer = "pngs_v1.1.9"
-outPath = "/p/user_pub/climate_work/durack1/Shared/150219_AMIPForcingData/"
-outPath = "."
+outPathVer = "pngs_v1.1.10"
+# outPath = "/p/user_pub/climate_work/durack1/Shared/150219_AMIPForcingData/"  # LLNL/detect
+outPath = "/global/homes/d/durack1/git/amipbcs"
 # New data
 verId = "v1.1.10"
-verPath = "/p/user_pub/climate_work/durack1/"
-verPath = "../"
-ver = "v20250729"  # Update for each run
+# verPath = "/p/user_pub/climate_work/durack1/"  # LLNL/detect
+# verPath = "../"
+verPath = "/global/homes/d/durack1/git/amipbcs"
+ver = "v20250804"  # Update for each run
 verPath = os.path.join(verPath, "input4MIPs/CMIP7/CMIP/PCMDI/PCMDI-AMIP-1-1-10/")
 print("verPath:", verPath)
 # tos_input4MIPs_SSTsAndSeaIce_CMIP_PCMDI-AMIP-1-2-0_gn_187001-202108.nc
 # Old data
 verOldId = "v1.1.9"
 verOld = "v20230512"  # Update for each run
-verOldPath = "/p/user_pub/work/input4MIPs/CMIP6Plus/CMIP/PCMDI/PCMDI-AMIP-1-1-9/"
-verOldPath = "../"
+# verOldPath = "/p/user_pub/work/input4MIPs/CMIP6Plus/CMIP/PCMDI/PCMDI-AMIP-1-1-9/"  # LLNL/detect
+# verOldPath = "../"
+verOldPath = "/global/cfs/projectdirs/m4931/gsharing/user_pub_work"
 verOldPath = os.path.join(
     verOldPath, "input4MIPs/CMIP6Plus/CMIP/PCMDI/PCMDI-AMIP-1-1-9/"
 )

--- a/src/matPlot.py
+++ b/src/matPlot.py
@@ -3,21 +3,23 @@
 """
 Created on Mon Sep 20 13:21:49 2021
 
-PJD 20 Sep 2021     - Started
-PJD 30 Sep 2021     - Updated for v20210930 data
-PJD 27 Oct 2021     - Updated to generate diff as % maps
-PJD  2 Nov 2021     - Updated following tweaks in https://github.com/PCMDI/amipbcs/issues/23#issuecomment-958164331
-PJD  3 May 2023     - Updates for the v1.1.9 data
-PJD  3 May 2023     - Updated for cdms2 -> xcdat
-PJD  3 May 2023     - Added plotter function
-PJD  4 May 2023     - Hitting issue with 2002-11 timestep and xarray DataArray plotting
-PJD  9 May 2023     - Add transform_first=True to contourf call
-PJD  9 May 2023     - Added +1 for last year, off by one PCMDI-AMIP-1-1-8 finishes in 2021-12
-PJD  9 May 2023     - Added ffmpeg call - installed ffmpeg-python
-PJD 10 May 2023     - Added statsStr to diff plot; updated diff scale <2%; corrected denom da1 vs s1 ref
-PJD 10 May 2023     - Add statsStr; update contour levels to target data
-PJD 12 May 2023     - Updated for latest v1.1.9 data run
-PJD 18 May 2023     - Compare v1.1.9 versions (released 20230512, and new mamba env 20230518)
+PJD 20 Sep 2021 - Started
+PJD 30 Sep 2021 - Updated for v20210930 data
+PJD 27 Oct 2021 - Updated to generate diff as % maps
+PJD  2 Nov 2021 - Updated following tweaks in https://github.com/PCMDI/amipbcs/issues/23#issuecomment-958164331
+PJD  3 May 2023 - Updates for the v1.1.9 data
+PJD  3 May 2023 - Updated for cdms2 -> xcdat
+PJD  3 May 2023 - Added plotter function
+PJD  4 May 2023 - Hitting issue with 2002-11 timestep and xarray DataArray plotting
+PJD  9 May 2023 - Add transform_first=True to contourf call
+PJD  9 May 2023 - Added +1 for last year, off by one PCMDI-AMIP-1-1-8 finishes in 2021-12
+PJD  9 May 2023 - Added ffmpeg call - installed ffmpeg-python
+PJD 10 May 2023 - Added statsStr to diff plot; updated diff scale <2%; corrected denom da1 vs s1 ref
+PJD 10 May 2023 - Add statsStr; update contour levels to target data
+PJD 12 May 2023 - Updated for latest v1.1.9 data run
+PJD 18 May 2023 - Compare v1.1.9 versions (released 20230512, and new mamba env 20230518)
+PJD 24 Jul 2025 - Updating for mac-local v1.1.10 vs v1.1.9
+PJD 29 Jul 2025 - Updating for mac-local v1.1.10 v20250724 -> 20250729
 
 @author: durack1
 """
@@ -32,6 +34,7 @@ import numpy as np
 import os
 import shutil
 from xcdat import open_dataset
+
 # import pdb
 
 # %% function defs
@@ -43,17 +46,39 @@ def statsStr(da):
 
     """
     fmtStr = "{:7.4f}"
-    statsStr = " ".join(["min:", fmtStr.format(da.min()),
-                         "\n1pc:", fmtStr.format(np.percentile(da, 1)),
-                         "\nmean:", fmtStr.format(da.mean()),
-                         "\n99pc:", fmtStr.format(np.percentile(da, 99)),
-                         "\nmax:", fmtStr.format(da.max())
-                         ])
+    statsStr = " ".join(
+        [
+            "min:",
+            fmtStr.format(da.min()),
+            "\n1pc:",
+            fmtStr.format(np.percentile(da, 1)),
+            "\nmean:",
+            fmtStr.format(da.mean()),
+            "\n99pc:",
+            fmtStr.format(np.percentile(da, 99)),
+            "\nmax:",
+            fmtStr.format(da.max()),
+        ]
+    )
 
     return statsStr
 
 
-def plotter(da1, da2, da1Str, da2Str, lev1, lev2, cmap, timeStr, titleString, varColStr, path, var, fileName):
+def plotter(
+    da1,
+    da2,
+    da1Str,
+    da2Str,
+    lev1,
+    lev2,
+    cmap,
+    timeStr,
+    titleString,
+    varColStr,
+    path,
+    var,
+    fileName,
+):
     """
     Generate generic plotting function
     """
@@ -68,14 +93,17 @@ def plotter(da1, da2, da1Str, da2Str, lev1, lev2, cmap, timeStr, titleString, va
     lat = np.tile(da1.lat.data, (360, 1)).transpose()
 
     # Start subplots
-    ax1 = fig.add_subplot(3, 1, 1,
-                          projection=ccrs.Robinson(
-                              central_longitude=centralLon,
-                              globe=None,
-                              false_easting=None,
-                              false_northing=None,
-                          ),
-                          )
+    ax1 = fig.add_subplot(
+        3,
+        1,
+        1,
+        projection=ccrs.Robinson(
+            central_longitude=centralLon,
+            globe=None,
+            false_easting=None,
+            false_northing=None,
+        ),
+    )
     # print("type(da1.lon):", type(da1.lon))
     # print("type(da1.lat):", type(da1.lat))
     # print("type(da1):", type(da1))
@@ -89,85 +117,118 @@ def plotter(da1, da2, da1Str, da2Str, lev1, lev2, cmap, timeStr, titleString, va
     # Failing line - only when an xarray DataArray is sent
     # cs1 = ax1.contourf(da1.lon, da1.lat, da1[0,],
     # cs1 = ax1.contourf(da1.lon.data, da1.lat.data, da1.squeeze().data,
-    cs1 = ax1.contourf(lon, lat, da1[0,],
-                       lev1,  # 20
-                       transform=ccrs.PlateCarree(),
-                       transform_first=True,
-                       cmap=cmap
-                       )
-    tx1 = plt.text(labX, labY, da1Str,
-                   fontsize=fntsz,
-                   horizontalalignment="center",
-                   transform=ccrs.Geodetic(),
-                   )
+    cs1 = ax1.contourf(
+        lon,
+        lat,
+        da1[0,],
+        lev1,  # 20
+        transform=ccrs.PlateCarree(),
+        transform_first=True,
+        cmap=cmap,
+    )
+    tx1 = plt.text(
+        labX,
+        labY,
+        da1Str,
+        fontsize=fntsz,
+        horizontalalignment="center",
+        transform=ccrs.Geodetic(),
+    )
     # create da1 dob variables
-    tx2 = plt.text(labX, labY-20, statsStr(da1),
-                   fontsize=fntsz,
-                   horizontalalignment="center",
-                   verticalalignment="center",
-                   transform=ccrs.Geodetic(),
-                   )
-    ax2 = fig.add_subplot(3, 1, 2,
-                          projection=ccrs.Robinson(
-                              central_longitude=centralLon,
-                              globe=None,
-                              false_easting=None,
-                              false_northing=None,
-                          ),
-                          )
-    cs2 = ax2.contourf(lon, lat, da2.squeeze().data,
-                       # cs2 = ax2.contourf(lo1, la1, x2,
-                       lev1,
-                       transform=ccrs.PlateCarree(),
-                       transform_first=True,
-                       cmap=cmap,
-                       )
-    tx3 = plt.text(labX, labY, da2Str,
-                   fontsize=fntsz,
-                   horizontalalignment="center",
-                   transform=ccrs.Geodetic(),
-                   )
+    tx2 = plt.text(
+        labX,
+        labY - 20,
+        statsStr(da1),
+        fontsize=fntsz,
+        horizontalalignment="center",
+        verticalalignment="center",
+        transform=ccrs.Geodetic(),
+    )
+    ax2 = fig.add_subplot(
+        3,
+        1,
+        2,
+        projection=ccrs.Robinson(
+            central_longitude=centralLon,
+            globe=None,
+            false_easting=None,
+            false_northing=None,
+        ),
+    )
+    cs2 = ax2.contourf(
+        lon,
+        lat,
+        da2.squeeze().data,
+        # cs2 = ax2.contourf(lo1, la1, x2,
+        lev1,
+        transform=ccrs.PlateCarree(),
+        transform_first=True,
+        cmap=cmap,
+    )
+    tx3 = plt.text(
+        labX,
+        labY,
+        da2Str,
+        fontsize=fntsz,
+        horizontalalignment="center",
+        transform=ccrs.Geodetic(),
+    )
     # create da2 dob variables
-    tx4 = plt.text(labX, labY-20, statsStr(da2),
-                   fontsize=fntsz,
-                   horizontalalignment="center",
-                   verticalalignment="center",
-                   transform=ccrs.Geodetic(),
-                   )
-    ax3 = fig.add_subplot(3, 1, 3,
-                          projection=ccrs.Robinson(
-                              central_longitude=centralLon,
-                              globe=None,
-                              false_easting=None,
-                              false_northing=None,
-                          ),
-                          )
+    tx4 = plt.text(
+        labX,
+        labY - 20,
+        statsStr(da2),
+        fontsize=fntsz,
+        horizontalalignment="center",
+        verticalalignment="center",
+        transform=ccrs.Geodetic(),
+    )
+    ax3 = fig.add_subplot(
+        3,
+        1,
+        3,
+        projection=ccrs.Robinson(
+            central_longitude=centralLon,
+            globe=None,
+            false_easting=None,
+            false_northing=None,
+        ),
+    )
     # Generate % change
-    diff = (da1[0,] - da2[0,])
+    diff = da1[0,] - da2[0,]
     inds = np.nonzero(diff.data)
     diffnew = np.ma.zeros(diff.shape)
     denom = (np.abs(da1[0,]) + np.abs(da2[0,])) / 2
     np.squeeze(denom).shape
     diffnew[inds] = diff.data[inds] / denom.data[inds]
 
-    cs3 = ax3.contourf(lon, lat, diffnew,
-                       lev2,
-                       transform=ccrs.PlateCarree(),
-                       transform_first=True,
-                       cmap=cmap,
-                       )
-    tx5 = plt.text(labX, labY, " ".join([da1Str, "-", da2Str]),
-                   fontsize=fntsz,
-                   horizontalalignment="center",
-                   transform=ccrs.Geodetic(),
-                   )
+    cs3 = ax3.contourf(
+        lon,
+        lat,
+        diffnew,
+        lev2,
+        transform=ccrs.PlateCarree(),
+        transform_first=True,
+        cmap=cmap,
+    )
+    tx5 = plt.text(
+        labX,
+        labY,
+        " ".join([da1Str, "-", da2Str]),
+        fontsize=fntsz,
+        horizontalalignment="center",
+        transform=ccrs.Geodetic(),
+    )
     # create diff dob variables
-    tx6 = plt.text(labX, labY-20, statsStr(diffnew),
-                   fontsize=fntsz,
-                   horizontalalignment="center",
-                   verticalalignment="center",
-                   transform=ccrs.Geodetic(),
-                   )
+    tx6 = plt.text(
+        labX,
+        labY - 20,
+        statsStr(diffnew),
+        fontsize=fntsz,
+        horizontalalignment="center",
+        verticalalignment="center",
+        transform=ccrs.Geodetic(),
+    )
 
     # make the map global rather than have it zoom in to the extents of
     # any plotted data ax.set_global()
@@ -215,8 +276,9 @@ def plotter(da1, da2, da1Str, da2Str, lev1, lev2, cmap, timeStr, titleString, va
 
     # pdb.set_trace()
     # plt.show()
-    if not os.path.exists(os.path.join(path)):
-        os.mkdir(os.path.join(path))
+    testPath = os.path.join(path)
+    if not os.path.exists(testPath):
+        os.mkdir(testPath)
     if not os.path.exists(os.path.join(path, var)):
         os.mkdir(os.path.join(path, var))
     fig.savefig(os.path.join(path, var, ".".join([fileName, "png"])), dpi=100)
@@ -227,22 +289,28 @@ def plotter(da1, da2, da1Str, da2Str, lev1, lev2, cmap, timeStr, titleString, va
 
 outPathVer = "pngs_v1.1.9"
 outPath = "/p/user_pub/climate_work/durack1/Shared/150219_AMIPForcingData/"
+outPath = "."
 # New data
-verId = "v1.1.9"
+verId = "v1.1.10"
 verPath = "/p/user_pub/climate_work/durack1/"
-ver = "v20230518"  # Update for each run
-verPath = os.path.join(
-    verPath, "input4MIPs/CMIP6Plus/CMIP/PCMDI/PCMDI-AMIP-1-1-9/")
+verPath = "../"
+ver = "v20250729"  # Update for each run
+verPath = os.path.join(verPath, "input4MIPs/CMIP7/CMIP/PCMDI/PCMDI-AMIP-1-1-10/")
+print("verPath:", verPath)
 # tos_input4MIPs_SSTsAndSeaIce_CMIP_PCMDI-AMIP-1-2-0_gn_187001-202108.nc
 # Old data
-verOldId = "v1.1.9-release"
+verOldId = "v1.1.9"
 verOld = "v20230512"  # Update for each run
 verOldPath = "/p/user_pub/work/input4MIPs/CMIP6Plus/CMIP/PCMDI/PCMDI-AMIP-1-1-9/"
+verOldPath = "../"
+verOldPath = os.path.join(
+    verOldPath, "input4MIPs/CMIP6Plus/CMIP/PCMDI/PCMDI-AMIP-1-1-9/"
+)
+print("verOldPath:", verOldPath)
 
 f1 = glob.glob("".join([verOldPath, "*/mon/siconc/gn/", verOld, "/*.nc"]))[0]
 f2 = glob.glob("".join([verPath, "*/mon/siconc/gn/", ver, "/*.nc"]))[0]
-f3 = glob.glob(
-    "".join([verOldPath, "*/mon/siconcbcs/gn/", verOld, "/*.nc"]))[0]
+f3 = glob.glob("".join([verOldPath, "*/mon/siconcbcs/gn/", verOld, "/*.nc"]))[0]
 f4 = glob.glob("".join([verPath, "*/mon/siconcbcs/gn/", ver, "/*.nc"]))[0]
 f5 = glob.glob("".join([verOldPath, "*/mon/tos/gn/", verOld, "/*.nc"]))[0]
 f6 = glob.glob("".join([verPath, "*/mon/tos/gn/", ver, "/*.nc"]))[0]
@@ -267,7 +335,7 @@ levs1 = list(np.arange(-10, 111, 10))  # siconc
 levs2 = list(np.arange(-150, 151, 10))  # siconcbcs
 levs3 = list(np.arange(-5, 36, 2.5))  # tos diff
 # levs3 = list(np.arange(-0.15, 0.1501, 0.05))  # tos diff
-levs4 = list(np.arange(0, 2.1, .1))  # % change
+levs4 = list(np.arange(0, 2.1, 0.1))  # % change
 
 # Lab x, y
 labX = -140.0
@@ -279,15 +347,17 @@ cmap = "cool"  # 'RdBu'
 
 # %% start looping
 # Do cleanup
-tmpPath = os.path.join(outPath, "pngs", outPathVer)
+tmpPath = os.path.join(outPath, "pngs", outPathVer, ver)
 if os.path.exists(tmpPath):
     shutil.rmtree(tmpPath)
+else:
+    os.makedirs(tmpPath, exist_ok=False)
 
 for var in ["siconc", "siconcbcs", "tos", "tosbcs"]:
-    for yr in np.arange(1870, ds1.time.data[-1].year+1):  # 1870
+    for yr in np.arange(1870, ds1.time.data[-1].year + 1):  # 1870
         for mn in np.arange(1, 13):
-            startTime = "-".join([str(yr), '{:02d}'.format(mn), "01"])
-            endTime = "-".join([str(yr), '{:02d}'.format(mn), "28"])
+            startTime = "-".join([str(yr), "{:02d}".format(mn), "01"])
+            endTime = "-".join([str(yr), "{:02d}".format(mn), "28"])
             print("start:", startTime, "end:", endTime)
             # load into arrays
             match var:
@@ -298,10 +368,8 @@ for var in ["siconc", "siconcbcs", "tos", "tosbcs"]:
                     cmap = "RdBu_r"
                     varColStr = "% coverage"
                 case "siconcbcs":
-                    s1 = eval(
-                        "ds3.siconcbcs.sel(time=slice(startTime, endTime))")
-                    s2 = eval(
-                        "ds4.siconcbcs.sel(time=slice(startTime, endTime))")
+                    s1 = eval("ds3.siconcbcs.sel(time=slice(startTime, endTime))")
+                    s2 = eval("ds4.siconcbcs.sel(time=slice(startTime, endTime))")
                     lev1 = levs2
                     cmap = "cool"
                     varColStr = "% coverage"
@@ -319,23 +387,45 @@ for var in ["siconc", "siconcbcs", "tos", "tosbcs"]:
                     varColStr = "degree_C"
 
             # get time from index
-            timeString = "{}{:02d}".format(
-                s1.time.data[0].year, s1.time.data[0].month)
+            timeString = "{}{:02d}".format(s1.time.data[0].year, s1.time.data[0].month)
             titleString = "{}{:02d}{}{}".format(
-                s1.time.data[0].year, s1.time.data[0].month, " ", var)
+                s1.time.data[0].year, s1.time.data[0].month, " ", var
+            )
 
-            plotter(s1, s2, verOldId, verId, lev1, levs4, cmap, timeString,
-                    titleString, varColStr, os.path.join(
-                        outPath, "pngs", outPathVer),
-                    var, timeString)
+            plotter(
+                s1,
+                s2,
+                verOldId,
+                verId,
+                lev1,
+                levs4,
+                cmap,
+                timeString,
+                titleString,
+                varColStr,
+                os.path.join(outPath, "pngs", outPathVer, ver),
+                var,
+                timeString,
+            )
             # pdb.set_trace()
     # end of var - plot video
     out, err = (
-        ffmpeg
-        .input(os.path.join(outPath, "pngs", outPathVer, var, "*.png"),
-               pattern_type='glob', framerate=25)
-        .output(os.path.join(outPath, "pngs", "_".join(["AMIPBCS_newVsOld", var, "v1-1-9.mp4"])),
-                crf=20, preset='slower', movflags='faststart', pix_fmt='yuv420p')
+        ffmpeg.input(
+            os.path.join(outPath, "pngs", outPathVer, ver, var, "*.png"),
+            pattern_type="glob",
+            framerate=25,
+        )
+        .output(
+            os.path.join(
+                outPath,
+                "pngs",
+                "_".join(["AMIPBCS_newVsOld", var, "v1-1-9", "".join([ver, ".mp4"])]),
+            ),
+            crf=20,
+            preset="slower",
+            movflags="faststart",
+            pix_fmt="yuv420p",
+        )
         .run()
     )
     # .view(filename='filter_graph')


### PR DESCRIPTION
This is a working branch attempting to resolve the problem with [0 100] siconcbcs truncation and [-1.8 ~] tosbcs truncation. These values should be unbound by these limits, which only apply to their siconc and tos observational origins.

Fix #33 

Please confirm that this pull request has done the following:

- [x] Data published on ESGF
- [ ] PCMDI/input4MIPs_CVs updated (see https://github.com/PCMDI/input4MIPs_CVs/pull/309)
- [x] Update README.md
- [ ] Did a new release after merging